### PR TITLE
Fix the definition files for new versions.

### DIFF
--- a/kubernetes/drupal.yaml
+++ b/kubernetes/drupal.yaml
@@ -27,13 +27,17 @@ spec:
     requests:
       storage: 10Gi
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: drupal
   labels:
     app: drupal
 spec:
+  selector:
+    matchLabels:
+      app: drupal
+      tier: frontend
   strategy:
     type: Recreate
   template:

--- a/kubernetes/postgres.yaml
+++ b/kubernetes/postgres.yaml
@@ -25,13 +25,17 @@ spec:
     requests:
       storage: 10Gi
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: postgresql
   labels:
     app: drupal
 spec:
+  selector:
+    matchLabels:
+      app: drupal
+      tier: postgreSQL
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
These fixes seemed to make the configuration files work again with a more recent version of Kubernetes.

Fixes #27.